### PR TITLE
Session between client and editorial - redis

### DIFF
--- a/client/src/main/java/com/client/ClientApplication.java
+++ b/client/src/main/java/com/client/ClientApplication.java
@@ -4,16 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.cloud.client.loadbalancer.LoadBalanced;
-import org.springframework.context.annotation.Bean;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
-import java.util.stream.Collectors;
 @EnableDiscoveryClient
 @SpringBootApplication
+@EnableRedisHttpSession
 @RestController
 public class ClientApplication {
 
@@ -21,7 +18,7 @@ public class ClientApplication {
     private String instanceId;
 
     @GetMapping("/client")
-    public String idTest(){
+    public String idTest() {
         return "Client app of id: " + instanceId;
     }
 

--- a/client/src/main/resources/application.properties
+++ b/client/src/main/resources/application.properties
@@ -7,3 +7,10 @@ server.port=0
 spring.datasource.url=jdbc:mysql://localhost:3306/userdb?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
 spring.datasource.password=
+
+# Redis (shared security session)
+spring.session.redis.namespace=spring:session
+spring.session.redis.flush-mode=on_save
+spring.session.redis.cleanup-cron=0 * * * * *
+spring.data.redis.port=8081
+spring.data.redis.host=localhost

--- a/editorial/src/main/java/com/editorial/EditorialApplication.java
+++ b/editorial/src/main/java/com/editorial/EditorialApplication.java
@@ -4,11 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @EnableDiscoveryClient
 @SpringBootApplication
+@EnableRedisHttpSession
 @RestController
 public class EditorialApplication {
 

--- a/editorial/src/main/resources/application.properties
+++ b/editorial/src/main/resources/application.properties
@@ -7,3 +7,10 @@ server.port=0
 spring.datasource.url=jdbc:mysql://localhost:3306/editorialdb?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
 spring.datasource.password=
+
+# Redis (shared security session)
+spring.session.redis.namespace=spring:session
+spring.session.redis.flush-mode=on_save
+spring.session.redis.cleanup-cron=0 * * * * *
+spring.data.redis.port=8081
+spring.data.redis.host=localhost


### PR DESCRIPTION
Added .properties configuration for client/editorial microservices to make a shared spring security session between them which is being held in Redis server (configured for port 8081). Also added @EnableRedisHttpSession to classes with spring boot main method and necessary dependencies (starter-data-redis and session-data-redis).